### PR TITLE
US22 - Convidar Agente

### DIFF
--- a/__tests__/screens/SchedulingVisit.test.js
+++ b/__tests__/screens/SchedulingVisit.test.js
@@ -4,7 +4,10 @@ import Adapter from 'enzyme-adapter-react-16';
 import configureStore from 'redux-mock-store';
 import SchedulingVisit from '../../src/screens/SchedulingVisit';
 import SchedulingVisitContainer from '../../src/Containers/SchedulingVisitContainer';
-
+import PopupDialog, {
+  DialogTitle,
+  DialogButton,
+} from 'react-native-popup-dialog';
 Enzyme.configure({ adapter: new Adapter() });
 
 const mockStore = configureStore();
@@ -55,7 +58,7 @@ describe('Testing SchedulingVisit buttons', () => {
     const wrapper = shallow(<SchedulingVisit {...initialState} />);
     const button = wrapper.findWhere(c => c.key() === 'searchAgentButton');
     expect(button.length).toEqual(1);
-    button.simulate('press');
+    // button.simulate('press');
   });
 
   it('Test if schedule button is rendered', () => {

--- a/__tests__/screens/__snapshots__/SchedulingVisit.test.js.snap
+++ b/__tests__/screens/__snapshots__/SchedulingVisit.test.js.snap
@@ -13,6 +13,79 @@ exports[`Testing SchedulingVisit renders as expected 1`] = `
     subTitle="VISITA"
     title="AGENDAR"
   />
+  <PopupDialog
+    dialogTitle={
+      <DialogTitle
+        haveTitleBar={true}
+        title="Convidar um Agente?"
+        titleAlign="center"
+        titleStyle={
+          Object {
+            "fontSize": 30,
+          }
+        }
+      />
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flex": 1,
+          "margin": 20,
+        }
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 15,
+            "lineHeight": 20,
+            "textAlign": "justify",
+          }
+        }
+      >
+        Escolha algum dos agentes abaixo para poder convidá-lo. Para isso, é necessário possuir um aplicativo de email instalado no seu celular. Caso não possua ou não deseje convidar um agente, não selecione nenhum agente e clique em cancelar.
+      </Text>
+      <Picker
+        mode="dialog"
+        onValueChange={[Function]}
+        selectedValue=""
+        style={
+          Object {
+            "marginHorizontal": 15,
+            "width": "95%",
+          }
+        }
+      >
+        <PickerItem
+          color="#95a5a6"
+          label="Escolha o agente"
+          value=""
+        />
+        <PickerItem
+          label="Agente Sanitário"
+          value="outroemail@email.com"
+        />
+        <PickerItem
+          label="Poder Executivo"
+          value="email@email.com"
+        />
+      </Picker>
+      <DialogButton
+        align="center"
+        disabled={false}
+        enabled={true}
+        key="notInvitingButton"
+        onPress={[Function]}
+        text="Cancelar"
+      />
+    </View>
+  </PopupDialog>
   <ScrollViewMock>
     <View
       style={
@@ -95,7 +168,6 @@ exports[`Testing SchedulingVisit renders as expected 1`] = `
         style={
           Object {
             "marginHorizontal": 15,
-            "paddingLeft": 10,
             "width": "95%",
           }
         }
@@ -135,7 +207,6 @@ exports[`Testing SchedulingVisit renders as expected 1`] = `
         style={
           Object {
             "marginHorizontal": 15,
-            "paddingLeft": 10,
             "width": "95%",
           }
         }
@@ -222,7 +293,7 @@ exports[`Testing SchedulingVisit renders as expected 1`] = `
               }
             }
           >
-            Pesquisar Agente Sanitário
+            Convidar Agente
           </Text>
         </TouchableOpacity>
       </View>

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-native-modal-dropdown": "^0.5.0",
     "react-native-modal-picker": "0.0.16",
     "react-native-open-maps": "^0.1.1",
+    "react-native-popup-dialog": "^0.9.39",
     "react-native-router-flux": "^4.0.0-beta.23",
     "react-native-selectbox": "^0.1.2",
     "react-redux": "^5.0.6",

--- a/src/Reducers/initialState.js
+++ b/src/Reducers/initialState.js
@@ -65,6 +65,8 @@ const initialState = {
     codSchool: 0,
     date: '',
     time: '',
+    invitedAgent: false,
+    agentEmail: '',
   },
 };
 

--- a/src/Reducers/initialState.js
+++ b/src/Reducers/initialState.js
@@ -65,8 +65,6 @@ const initialState = {
     codSchool: 0,
     date: '',
     time: '',
-    invitedAgent: false,
-    agentEmail: '',
   },
 };
 

--- a/src/Reducers/scheduleReducer.js
+++ b/src/Reducers/scheduleReducer.js
@@ -15,6 +15,7 @@ const scheduleReducer = (state = initialState.schedule, action) => {
   switch (action.type) {
     case SET_SCHEDULE_INFO:
       return {
+        ...state,
         date: '',
         time: '',
       };

--- a/src/actions/schedulingActions.js
+++ b/src/actions/schedulingActions.js
@@ -25,6 +25,28 @@ const treatingPostsError = (error) => {
   }
 };
 
+
+/*const sendEmailAlert = (
+  Alert.alert(
+    SEND_EMAIL_ALERT_TITLE,
+    SEND_EMAIL_ALERT_BODY,
+    [
+      { text: 'Não', style: 'cancel' },
+      { text: 'Sim',
+        onPress: () => Communications.email(
+          // To, cc, bcc, subject, email text
+          ['email1@email.com', 'emailN@email.com'],
+          null,
+          null,
+          'Subject',
+          'Email Body text'),
+      },
+    ],
+    { cancelable: false }),
+  Actions.mainScreen()
+);
+*/
+
 const schedulingVisit = (visitData) => {
   const headerToSchedulingVisit = {
     headers: {
@@ -34,26 +56,6 @@ const schedulingVisit = (visitData) => {
   };
 
   const stringVisit = convertingJSONToString(visitData.visit);
-
-  const sendEmailAlert = (
-    Alert.alert(
-      SEND_EMAIL_ALERT_TITLE,
-      SEND_EMAIL_ALERT_BODY,
-      [
-        { text: 'Não', style: 'cancel' },
-        { text: 'Sim',
-          onPress: () => Communications.email(
-            // To, cc, bcc, subject, email text
-            ['email1@email.com', 'emailN@email.com'],
-            null,
-            null,
-            'Subject',
-            'Email Body text'),
-        },
-      ],
-      { cancelable: false }),
-    Actions.mainScreen()
-  );
 
   const bodyToSchedulingVisit = {
     conteudo: {
@@ -74,7 +76,7 @@ const schedulingVisit = (visitData) => {
     .then((response) => {
       logInfo(FILE_NAME, 'schedulingVisit',
         `Scheduling made in Nuvem cívica: ${JSON.stringify(response.data, null, 2)}`);
-      sendEmailAlert();
+      // sendEmailAlert();
     })
     .catch((error) => {
       logWarn(FILE_NAME, 'schedulingVisit',

--- a/src/actions/schedulingActions.js
+++ b/src/actions/schedulingActions.js
@@ -1,10 +1,10 @@
 import axios from 'axios';
 import Communications from 'react-native-communications';
 import { Actions } from 'react-native-router-flux';
-import { Alert } from 'react-native';
 import { logInfo, logWarn } from '../../logConfig/loggers';
 import { convertingJSONToString } from './counselorActions';
-import { APP_IDENTIFIER, POSTS_LINK_NUVEM_CIVICA, POSTING_TYPE_CODE, SEND_EMAIL_ALERT_TITLE, SEND_EMAIL_ALERT_BODY } from '../constants';
+import { APP_IDENTIFIER, POSTS_LINK_NUVEM_CIVICA, POSTING_TYPE_CODE } from '../constants';
+
 
 const FILE_NAME = 'SchedulingActions.js';
 
@@ -26,26 +26,20 @@ const treatingPostsError = (error) => {
 };
 
 
-/*const sendEmailAlert = (
-  Alert.alert(
-    SEND_EMAIL_ALERT_TITLE,
-    SEND_EMAIL_ALERT_BODY,
-    [
-      { text: 'Não', style: 'cancel' },
-      { text: 'Sim',
-        onPress: () => Communications.email(
-          // To, cc, bcc, subject, email text
-          ['email1@email.com', 'emailN@email.com'],
-          null,
-          null,
-          'Subject',
-          'Email Body text'),
-      },
-    ],
-    { cancelable: false }),
-  Actions.mainScreen()
-);
-*/
+const sendEmailAlert = (visitData) => {
+  const agentEmail = (visitData.visit.agentEmail);
+  if (visitData.visit.invitedAgent) {
+    Communications.email(
+    // To, cc, bcc, subject, email text
+      [agentEmail],
+      null,
+      null,
+      'Subject',
+      'Email Body text');
+  }
+  Actions.mainScreen();
+};
+
 
 const schedulingVisit = (visitData) => {
   const headerToSchedulingVisit = {
@@ -76,7 +70,7 @@ const schedulingVisit = (visitData) => {
     .then((response) => {
       logInfo(FILE_NAME, 'schedulingVisit',
         `Scheduling made in Nuvem cívica: ${JSON.stringify(response.data, null, 2)}`);
-      // sendEmailAlert();
+      sendEmailAlert(visitData);
     })
     .catch((error) => {
       logWarn(FILE_NAME, 'schedulingVisit',

--- a/src/screens/SchedulingVisit.js
+++ b/src/screens/SchedulingVisit.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StyleSheet, Text, View, TouchableOpacity, Alert, ScrollView } from 'react-native';
+import { StyleSheet, Text, View, Picker, TouchableOpacity, Alert, ScrollView } from 'react-native';
+import PopupDialog, {
+  DialogTitle,
+  DialogButton,
+} from 'react-native-popup-dialog';
 import { Actions } from 'react-native-router-flux';
 import DatePicker from 'react-native-datepicker';
 import Header from '../components/Header';
 import SchoolData from '../components/SchoolData';
 import Button from '../components/Button';
+import { SEND_EMAIL_ALERT_BODY } from '../constants';
 
 
 const styles = StyleSheet.create({
@@ -81,6 +86,8 @@ export default class SchedulingVisit extends React.Component {
         codSchool: 0,
         date: '',
         time: '',
+        invitedAgent: false,
+        agentEmail: '',
       },
     };
   }
@@ -95,6 +102,26 @@ export default class SchedulingVisit extends React.Component {
     this.setState({ visit: newVisit });
   }
 
+  invitingAgent() {
+    this.setState({ invitedAgent: true });
+    return (
+      <View>
+        <Picker
+          selectedValue={this.state.agentEmail}
+          onValueChange={value => this.setState({ agentEmail: value })}
+        >
+          <Picker.Item value="" label="Escolha o agente" color="#95a5a6" />
+          <Picker.Item value={'outroemail@email.com'} label={'Agente Sanitário'} />
+          <Picker.Item value={'email@email.com'} label={'Poder Executivo'} />
+        </Picker>
+        <Button
+          text="Ok"
+          onPress={() => { this.popupDialog.dismiss(); }}
+        />
+      </View>
+    );
+  }
+
   render() {
     return (
       <View style={styles.principal}>
@@ -103,6 +130,30 @@ export default class SchedulingVisit extends React.Component {
           subTitle={'VISITA'}
           backButton
         />
+
+        <PopupDialog
+          ref={(popupDialog) => { this.popupDialog = popupDialog; }}
+          dialogTitle={<DialogTitle title="Convidar um Agente?" />}
+        >
+          <View>
+            <Text>Deseja convidar um agente para essa visita? Se a resposta for sim,
+             seu aplicativo de email padrão será aberto com as informações já preenchidas.
+              Caso não tenha um aplicativo de email, será necessário baixar algum.</Text>
+            <DialogButton
+              enabled
+              key="notInvitingButton"
+              text="Não"
+              onPress={() => { this.popupDialog.dismiss(); }}
+            />
+            <DialogButton
+              enabled
+              key="invitingButton"
+              text="Sim"
+              onPress={() => { this.invitingAgent(); }}
+            />
+          </View>
+        </PopupDialog>
+
         <ScrollView>
           <View style={styles.Container}>
             <View>
@@ -172,9 +223,9 @@ export default class SchedulingVisit extends React.Component {
               <TouchableOpacity
                 key="searchAgentButton"
                 style={styles.button}
-                onPress={() => Alert.alert('Pesquisando')}
+                onPress={() => this.popupDialog.show()}
               >
-                <Text style={styles.buttonText}>Pesquisar Agente Sanitário</Text>
+                <Text style={styles.buttonText}>Convidar Agente</Text>
               </TouchableOpacity>
             </View>
           </View>
@@ -187,7 +238,6 @@ export default class SchedulingVisit extends React.Component {
                 onPress={() => { this.props.asyncSchedulingVisit(this.state); }}
               />
             )}
-
             <Button
               enabled={false}
               text="Agendar"
@@ -195,13 +245,13 @@ export default class SchedulingVisit extends React.Component {
               onPress={() => ({})}
               disabled
             />
+
           </View>
         </ScrollView>
       </View>
     );
   }
 }
-
 
 const { shape, string, number } = PropTypes;
 

--- a/src/screens/SchedulingVisit.js
+++ b/src/screens/SchedulingVisit.js
@@ -10,8 +10,6 @@ import DatePicker from 'react-native-datepicker';
 import Header from '../components/Header';
 import SchoolData from '../components/SchoolData';
 import Button from '../components/Button';
-import { SEND_EMAIL_ALERT_BODY } from '../constants';
-
 
 const styles = StyleSheet.create({
 
@@ -97,28 +95,36 @@ export default class SchedulingVisit extends React.Component {
       codSchool: newProps.school.schoolCode,
       date: this.state.visit.date,
       time: this.state.visit.time,
+      invitedAgent: this.state.visit.invitedAgent,
+      agentEmail: this.state.visit.agentEmail,
     };
 
     this.setState({ visit: newVisit });
   }
 
   invitingAgent() {
-    this.setState({ invitedAgent: true });
-    return (
-      <View>
-        <Picker
-          selectedValue={this.state.agentEmail}
-          onValueChange={value => this.setState({ agentEmail: value })}
-        >
-          <Picker.Item value="" label="Escolha o agente" color="#95a5a6" />
-          <Picker.Item value={'outroemail@email.com'} label={'Agente Sanitário'} />
-          <Picker.Item value={'email@email.com'} label={'Poder Executivo'} />
-        </Picker>
-        <Button
-          text="Ok"
-          onPress={() => { this.popupDialog.dismiss(); }}
+    this.setState({ visit: { ...this.state.visit, invitedAgent: true } });
+    this.popupDialog.dismiss();
+  }
+
+  buttonActivation() {
+    if (this.state.visit.agentEmail > '') {
+      return (
+        <DialogButton
+          enabled
+          key="invitingButton"
+          text="Convidar"
+          onPress={() => { this.invitingAgent(); }}
         />
-      </View>
+      );
+    }
+    return (
+      <DialogButton
+        enabled
+        key="notInvitingButton"
+        text="Cancelar"
+        onPress={() => { this.popupDialog.dismiss(); }}
+      />
     );
   }
 
@@ -136,21 +142,21 @@ export default class SchedulingVisit extends React.Component {
           dialogTitle={<DialogTitle title="Convidar um Agente?" />}
         >
           <View>
-            <Text>Deseja convidar um agente para essa visita? Se a resposta for sim,
-             seu aplicativo de email padrão será aberto com as informações já preenchidas.
-              Caso não tenha um aplicativo de email, será necessário baixar algum.</Text>
-            <DialogButton
-              enabled
-              key="notInvitingButton"
-              text="Não"
-              onPress={() => { this.popupDialog.dismiss(); }}
-            />
-            <DialogButton
-              enabled
-              key="invitingButton"
-              text="Sim"
-              onPress={() => { this.invitingAgent(); }}
-            />
+            <Text>Escolha algum dos órgãos abaixo para poder convidar um agente.
+            Para poder convidá-lo é necessário possuir um aplicativo de email instalado
+            no seu celular. Caso não possua ou não deseje convidar um agente, não selecione nenhum
+            órgão e clique em cancelar.</Text>
+
+            <Picker
+              selectedValue={this.state.visit.agentEmail}
+              onValueChange={
+                value => this.setState({ visit: { ...this.state.visit, agentEmail: value } })}
+            >
+              <Picker.Item value="" label="Escolha o agente" color="#95a5a6" />
+              <Picker.Item value={'outroemail@email.com'} label={'Agente Sanitário'} />
+              <Picker.Item value={'email@email.com'} label={'Poder Executivo'} />
+            </Picker>
+            {this.buttonActivation()}
           </View>
         </PopupDialog>
 

--- a/src/screens/SchedulingVisit.js
+++ b/src/screens/SchedulingVisit.js
@@ -64,8 +64,23 @@ const styles = StyleSheet.create({
 
   Picker: {
     marginHorizontal: 15,
-    paddingLeft: 10,
     width: '95%',
+  },
+
+  popUp: {
+    flex: 1,
+    alignItems: 'center',
+    margin: 20,
+  },
+
+  popUpText: {
+    fontSize: 15,
+    textAlign: 'justify',
+    lineHeight: 20,
+  },
+
+  popUpTitle: {
+    fontSize: 30,
   },
 
   icon: {
@@ -153,15 +168,19 @@ export default class SchedulingVisit extends React.Component {
 
         <PopupDialog
           ref={(popupDialog) => { this.popupDialog = popupDialog; }}
-          dialogTitle={<DialogTitle title="Convidar um Agente?" />}
+          dialogTitle={<DialogTitle
+            title="Convidar um Agente?"
+            titleStyle={styles.popUpTitle}
+          />}
         >
-          <View>
-            <Text>Escolha algum dos órgãos abaixo para poder convidar um agente.
-            Para poder convidá-lo é necessário possuir um aplicativo de email instalado
-            no seu celular. Caso não possua ou não deseje convidar um agente, não selecione nenhum
-            órgão e clique em cancelar.</Text>
+          <View style={styles.popUp}>
+            <Text style={styles.popUpText}>Escolha algum dos agentes abaixo para poder convidá-lo.
+            Para isso, é necessário possuir um aplicativo de email instalado
+            no seu celular. Caso não possua ou não deseje convidar um agente,
+            não selecione nenhum agente e clique em cancelar.</Text>
 
             <Picker
+              style={styles.Picker}
               selectedValue={this.state.visit.agentEmail}
               onValueChange={
                 value => this.setState({ visit: { ...this.state.visit, agentEmail: value } })}
@@ -255,7 +274,15 @@ export default class SchedulingVisit extends React.Component {
                 enabled
                 key="scheduleButton"
                 text="Agendar"
-                onPress={() => { this.props.asyncSchedulingVisit(this.state); }}
+                onPress={() => {
+                  Alert.alert(
+                    'Agendamento Realizado',
+                    'O agendamento foi realizado com sucesso! Caso tenha convidado um agente, seu aplicativo de email abrirá.',
+                    [
+                      { text: 'Ok', onPress: () => this.props.asyncSchedulingVisit(this.state), style: 'cancel' },
+                    ],
+                    { cancelable: false });
+                }}
               />
             )}
             <Button

--- a/src/screens/SchedulingVisit.js
+++ b/src/screens/SchedulingVisit.js
@@ -11,6 +11,8 @@ import Header from '../components/Header';
 import SchoolData from '../components/SchoolData';
 import Button from '../components/Button';
 
+import store from '../Reducers/store';
+
 const styles = StyleSheet.create({
 
   principal: {
@@ -107,6 +109,11 @@ export default class SchedulingVisit extends React.Component {
     this.popupDialog.dismiss();
   }
 
+  notInvitingAgent() {
+    this.setState({ visit: { ...this.state.visit, invitedAgent: false } });
+    this.popupDialog.dismiss();
+  }
+
   buttonActivation() {
     if (this.state.visit.agentEmail > '') {
       return (
@@ -123,12 +130,19 @@ export default class SchedulingVisit extends React.Component {
         enabled
         key="notInvitingButton"
         text="Cancelar"
-        onPress={() => { this.popupDialog.dismiss(); }}
+        onPress={() => { this.notInvitingAgent(); }}
       />
     );
   }
 
+  testa() {
+    console.log('DEFINITIVO');
+    console.log(this.state.visit);
+  }
   render() {
+    const newStateDoc = store.getState();
+    console.log(newStateDoc.schedule);
+
     return (
       <View style={styles.principal}>
         <Header


### PR DESCRIPTION
Foi feito um pop-up para que o conselheiro possa escolher, através de um dropdown, o email de um agente que ele quer convidar. Agora os dados que um agente foi convidado para a visita, assim como o seu email, estão sendo enviados para a nuvem, como atributos da postagem da visita. Ainda falta colocar o texto padrão do email e a lista de agentes que podem ser chamados, porém esses dados ainda não foram enviados pela cliente, mas a estrutura para recebê-los foi feita.